### PR TITLE
pin the gemspec to a newer rspec version that is compatible with mocha >...

### DIFF
--- a/bodeco_module_helper.gemspec
+++ b/bodeco_module_helper.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_runtime_dependency 'r10k'
-  s.add_runtime_dependency 'rspec', '~> 2.11.0'
+  s.add_runtime_dependency 'rspec', '~> 2.14'
   s.add_runtime_dependency 'puppetlabs_spec_helper', '~> 0.7.0'
   s.add_runtime_dependency 'puppet-blacksmith'
 


### PR DESCRIPTION
... 0.12.8
- see https://github.com/freerange/mocha/issues/130
- without this fix rspec tries to use mocha/object which was removed from mocha
