### PR TITLE
removed pinning of puppetlabs_spec_helper and rspec

### DIFF
--- a/bodeco_module_helper.gemspec
+++ b/bodeco_module_helper.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
   end
 
   s.add_runtime_dependency 'r10k'
-  s.add_runtime_dependency 'rspec', '~> 2.14'
-  s.add_runtime_dependency 'puppetlabs_spec_helper', '~> 0.7.0'
+  s.add_runtime_dependency 'rspec'
+  s.add_runtime_dependency 'puppetlabs_spec_helper', '~> 0.8'
   s.add_runtime_dependency 'puppet-blacksmith'
 
   s.files = Dir.glob('lib/**/*') + %w(LICENSE)


### PR DESCRIPTION
- previously this was being pinned due to an issue
  with puppet-syntax being loaded which autoloads puppet.
  - a PR was submitted to update puppet-syntax to lazy load puppet which has been merged.
