### PR TITLE
ensure fixtures directory exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle
+.idea
 .ruby-version
 *.gem
 Gemfile.lock

--- a/lib/bodeco_module_helper/rake_tasks.rb
+++ b/lib/bodeco_module_helper/rake_tasks.rb
@@ -89,6 +89,7 @@ end
 # Cleanup vagrant environment
 desc 'Vagrant VM shutdown and fixtures cleanup'
 task :vagrant_destroy do
+  Rake::Task['spec_prep'].execute
   `vagrant destroy -f`
   Rake::Task['spec_clean'].execute
 end


### PR DESCRIPTION
  * in rare cases when a vagrantfile is used and references
    the bodeco module helper vagrant code in a relative path
    under the fixtures directory.  We need to ensure the fixtures directory
    exists otherwise the rake task will fail to execute trying to load a file that doesn't exist.