### PR TITLE
ignore *.pp files from vendor

### DIFF
--- a/lib/bodeco_module_helper/rake_tasks.rb
+++ b/lib/bodeco_module_helper/rake_tasks.rb
@@ -50,7 +50,7 @@ task :lint do
   PuppetLint.configuration.disable_arrow_alignment
   PuppetLint.configuration.disable_class_inherits_from_params_class
   PuppetLint.configuration.disable_class_parameter_defaults
-  PuppetLint.configuration.ignore_paths = ['spec/**/*.pp', 'pkg/**/*.pp']
+  PuppetLint.configuration.ignore_paths = ['spec/**/*.pp', 'pkg/**/*.pp', 'vendor/**/*.pp']
 end
 
 desc 'Validate puppet manifests, ERB templates, and Ruby files.'


### PR DESCRIPTION
the new container caching feature from travis
caches ruby gems in vendor. Some of the gems we
install have .pp files which are getting lint checked.

This patch ignores pp files from vendor so that
travisci gem caching can work!!!