### PR TITLE
ensure the os_type gets the correct variable passed in

### DIFF
--- a/lib/bodeco_module_helper/vagrant.rb
+++ b/lib/bodeco_module_helper/vagrant.rb
@@ -5,7 +5,7 @@ def vm(opt)
   cpu = opt.fetch(:cpu, 1)
   box = opt.fetch(:box).to_s || raise(ArgumentError, 'Must provide box type.')
   url = opt.fetch(:url, '').to_s
-  os_type = opt.fetch(:type, :linux)
+  os_type = opt[:os_type] || opt[:type] || :linux
   gui = opt.fetch(:gui, false)
   port = opt.fetch(:port, nil)
   iso = opt.fetch(:iso, nil)


### PR DESCRIPTION
  * previously the os_type variable was not being assigned correctly,
    thus causing windows shared folders to be mapped like a linux system.
    This caused vagrant_up to not work as intended.