### PR TITLE
gh-8 - vagrant_up task does not work on windows

### DIFF
--- a/lib/bodeco_module_helper/rake_tasks.rb
+++ b/lib/bodeco_module_helper/rake_tasks.rb
@@ -77,13 +77,12 @@ desc 'Vagrant VM power up and provision'
 task :vagrant_up, [:manifest, :hostname] do |t, args|
   args.with_defaults(:manifest => 'init.pp', :hostname => '')
   Rake::Task['spec_prep'].execute
-
-  env = "VAGRANT_MANIFEST='#{args[:manifest]}'"
+  ENV['VAGRANT_MANIFEST'] = args[:manifest]
   provision = false
-  io_popen("export #{env}; vagrant up #{args[:hostname]}") do |line|
+  io_popen("vagrant up #{args[:hostname]}") do |line|
     provision = true if line =~ /is already running./
   end
-  io_popen("export #{env}; vagrant provision #{args[:hostname]}") if provision
+  io_popen("vagrant provision #{args[:hostname]}") if provision
 end
 
 # Cleanup vagrant environment


### PR DESCRIPTION
  - previously we were exporting variables which did not work on windows
    Now we set the environment variable which works on all platforms