### PR TITLE
pin puppetlabs_spec_helper to version 0.9.x

### DIFF
--- a/bodeco_module_helper.gemspec
+++ b/bodeco_module_helper.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'r10k'
   s.add_runtime_dependency 'rspec'
-  s.add_runtime_dependency 'puppetlabs_spec_helper', '~> 0.8'
+  s.add_runtime_dependency 'puppetlabs_spec_helper', '~> 0.9'
   s.add_runtime_dependency 'puppet-blacksmith'
   s.add_runtime_dependency 'rspec-puppet-utils'
 


### PR DESCRIPTION
The new version of puppet labs_spec_helper has been released.

  * this fixes a issue on windows where symlinks were not handled correctly 
    and unit testing did not work as a result.  This update fixes that issue.